### PR TITLE
Revert "Emit extra diagnostic output"

### DIFF
--- a/setup
+++ b/setup
@@ -138,16 +138,4 @@ start datalad-tests-ssh 42241
 # Ideally the same source directory wouldn't be used for the mounts,
 # but DataLad tests rely on it.
 test -n "$two" && start datalad-tests-ssh2 42242
-
-docker ps -a
-echo 'BEGIN datalad-tests-ssh LOGS --------'
-docker logs datalad-tests-ssh
-echo 'END datalad-tests-ssh LOGS --------'
-if test -n "$two"
-then
-    echo 'BEGIN datalad-tests-ssh2 LOGS --------'
-    docker logs datalad-tests-ssh2
-    echo 'END datalad-tests-ssh2 LOGS --------'
-fi
-
 exit 0


### PR DESCRIPTION
This reverts commit 679b59d11725dafa0da2d9e5b4305d39b606dd98.

This change is no longer needed, and it wasn't that helpful to begin with.